### PR TITLE
update README.ME file with new go instlalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ as `github-clone-all 'foo bar'`.
 
 ## Installation
 
-Use `go get` or [released binaries](https://github.com/rhysd/github-clone-all/releases).
+Use `go install` or [released binaries](https://github.com/rhysd/github-clone-all/releases).
 
 ```
-$ go get github.com/rhysd/github-clone-all
+$ go install github.com/rhysd/github-clone-all@latest
+$ github-clone-all
+
 ```
 
 
@@ -64,6 +66,7 @@ $ github-clone-all -dry 'language:go'
 ```
 
 The above command will only list up most popular 1000 repositories of Go instead of cloning them.
+
 
 ```
 $ github-clone-all -deep -ssh 'user:YOUR_USER_NAME fork:false'

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ $ github-clone-all -dry 'language:go'
 
 The above command will only list up most popular 1000 repositories of Go instead of cloning them.
 
-
 ```
 $ github-clone-all -deep -ssh 'user:YOUR_USER_NAME fork:false'
 ```


### PR DESCRIPTION
go get is not working anymore in golang > 1.17. it's recommended to use `go install`